### PR TITLE
Update about page, curate projects, add dark mode toggle

### DIFF
--- a/homepage/content/_index.md
+++ b/homepage/content/_index.md
@@ -7,11 +7,11 @@ comment: "This file needs to be _index.md. If it is index.md /posts isn't workin
 
 ## About me
 
-My name is Christopher Loessl. Currently working as a Senior Security Engineering Manager at [Visa](https://www.visa.com).
+My name is Christopher Loessl. I'm a Senior Security Engineering Manager at [Visa](https://www.visa.com), where I build and lead teams that secure systems at scale.
 
-I'm a devoted security and software engineer, interested in security, operating systems, networking and mobile, with 20+ years of Linux/Unix and 15+ years of professional software development experience.
+With 25+ years of experience in software development, Linux/Unix, networking, and security, I bring both hands-on technical depth and leadership — from defining architecture and running incident response to shipping code and reviewing pull requests. I've contributed to open-source projects like [VLC](https://www.videolan.org/vlc/), [OWASP ASVS](https://owasp.org/www-project-application-security-verification-standard/), [Adium](https://adium.im/), and [NewsBlur](https://www.newsblur.com/).
 
-Skilled in developing and executing strategic plans, conducting risk assessments, and leading teams. Specialized in security architecture, application security, cloud security, security operations, incident response, cybersecurity, and more. Proven track record of contributing to open-source projects such as VLC, OWASP, ASVS, Adium, and Newsblur.
+My background spans application security, cloud security, security operations, and team building. I care about getting the fundamentals right — whether that's a threat model, a CI pipeline, or a C program.
 
 In my free time, I enjoy reading 📚, hiking 🏔️, climbing 🧗, squash, and exploring the universe with my 8” Dobsonian telescope 🔭.
 

--- a/homepage/content/_index.md
+++ b/homepage/content/_index.md
@@ -9,7 +9,7 @@ comment: "This file needs to be _index.md. If it is index.md /posts isn't workin
 
 My name is Christopher Loessl. I'm a Senior Security Engineering Manager at [Visa](https://www.visa.com), where I build and lead teams that secure systems at scale.
 
-With 25+ years of experience in software development, Linux/Unix, networking, and security, I bring both hands-on technical depth and leadership — from defining architecture and running incident response to shipping code to 100+ million users. I've contributed to open-source projects like [VLC](https://www.videolan.org/vlc/), [OWASP ASVS](https://owasp.org/www-project-application-security-verification-standard/), [Adium](https://adium.im/), and [NewsBlur](https://www.newsblur.com/).
+With 25+ years of experience in software development, Linux/Unix, networking, and security, I bring both hands-on technical depth and leadership — from defining security strategy and embedding security into engineering culture to shipping code to hundreds of millions of users. I've contributed to open-source projects like [VLC](https://www.videolan.org/vlc/), [OWASP ASVS](https://owasp.org/www-project-application-security-verification-standard/), [Adium](https://adium.im/), and [NewsBlur](https://www.newsblur.com/).
 
 My background spans application security, cloud security, security operations, and team building. I care about getting the fundamentals right — whether that's a threat model, a CI pipeline, or a C program.
 

--- a/homepage/content/_index.md
+++ b/homepage/content/_index.md
@@ -9,7 +9,7 @@ comment: "This file needs to be _index.md. If it is index.md /posts isn't workin
 
 My name is Christopher Loessl. I'm a Senior Security Engineering Manager at [Visa](https://www.visa.com), where I build and lead teams that secure systems at scale.
 
-With 25+ years of experience in software development, Linux/Unix, networking, and security, I bring both hands-on technical depth and leadership — from defining architecture and running incident response to shipping code and reviewing pull requests. I've contributed to open-source projects like [VLC](https://www.videolan.org/vlc/), [OWASP ASVS](https://owasp.org/www-project-application-security-verification-standard/), [Adium](https://adium.im/), and [NewsBlur](https://www.newsblur.com/).
+With 25+ years of experience in software development, Linux/Unix, networking, and security, I bring both hands-on technical depth and leadership — from defining architecture and running incident response to shipping code to 100+ million users. I've contributed to open-source projects like [VLC](https://www.videolan.org/vlc/), [OWASP ASVS](https://owasp.org/www-project-application-security-verification-standard/), [Adium](https://adium.im/), and [NewsBlur](https://www.newsblur.com/).
 
 My background spans application security, cloud security, security operations, and team building. I care about getting the fundamentals right — whether that's a threat model, a CI pipeline, or a C program.
 

--- a/homepage/content/projects.md
+++ b/homepage/content/projects.md
@@ -1,85 +1,71 @@
 ---
-title: "Some of my projects"
+title: "Projects"
 date: 2020-06-06T20:07:58+02:00
 tags: ["static-page", "index"]
 ---
 
-This is a small (incomplete) list of projects that I have started over the years and that have had some impact on me in one way or another.
-Starting with my very first successful C project that allowed transfer of files between a famous gateway router ([fli4l](https://fli4l.de)) and a local machine, flicp.
+A selection of projects I've built over the years. More on [GitHub](https://github.com/hashier).
 
-You can find most of my projects on [Github](https://github.com) or by clicking on them below.
+## [Voronoi Subway Map](https://github.com/hashier/voronoi-subway-map)
 
-## [1-2-animation](https://hashier.github.io/1-2-animation/)
+Generates a colored Voronoi diagram overlaid on OpenStreetMap showing the closest subway station from any point in the city. Try the [live demo](https://nearest-station.loessl.org/).
 
-This command line tool generates Poemotion images.
-These are 2D images that provide an optical illusion of being 3D when viewed with a striped masked.
+![Voronoi map of Stockholm subway stations](https://raw.githubusercontent.com/hashier/voronoi-subway-map/main/img/img.jpg)
 
-A video of this effect can be found on the project's GitHub page.
+{{< langUsed >}}HTML, JavaScript.{{< /langUsed >}}
 
-Written in Go.
+## [TRMNL Norway Departures](https://github.com/hashier/trmnl-norway-departures)
 
-## [Spotify Playlist Manager](https://hashier.github.io/Bucketify/)
+Plugin for the [TRMNL](https://usetrmnl.com/) e-ink display that shows real-time public transport departures in Norway.
 
-This app helps you to manage and filter your Spotify Playlist.
+<!-- TODO: add image -->
 
-Whether you want to filtering your playlists by genre, country of artist or just simply randomise it, this app can do it for you.
+{{< langUsed >}}Python.{{< /langUsed >}}
 
-Written in Objective-C with different Frameworks like CocoaLibSpotify and ENiOS.
+## [1-2-animation](https://github.com/hashier/1-2-animation)
 
-## [idleSound](https://hashier.github.io/idleSound/)
+Generates Poemotion images — 2D patterns that create an optical illusion of motion when viewed through a striped overlay. [Video demo](https://youtu.be/wS_h5yDLNzM).
 
-Automatically mute your Mac when it becomes idle or your screen locks.
+![1-2-animation example](https://raw.githubusercontent.com/hashier/1-2-animation/master/example/example-color-5-out.png)
 
-Idle time as well as the screen-lock/screen-saver are individually adjustable.
-
-Mac Menubar UI App, written in Objective-C.
-
-## [SSKeychain](https://github.com/soffes/sskeychain/)
-
-Objective-C wrapper around the iOS/OS X keychain.
-I wrote the unit tests for almost the whole code base.
-
-Written in Objective-C.
+{{< langUsed >}}Go.{{< /langUsed >}}
 
 ## [MacFolket](https://hashier.github.io/MacFolket/)
 
-MacFolket is a Swedish/English dictionary that is deeply integrated into OS X.
+A Swedish/English dictionary deeply integrated into macOS — look up words system-wide via the native dictionary popup. 78 stars on GitHub. Installable via [Homebrew](https://github.com/hashier/homebrew-macfolket).
 
-After finding a dictionary database under the CC license, I decided to develop a program that facilitates reading Swedish webpages.
+![MacFolket dictionary lookup](https://raw.githubusercontent.com/hashier/MacFolket/master/images/svendict.jpg)
 
-Implemented in XSLT (I started a Golang rewrite recently).
+{{< langUsed >}}XSLT.{{< /langUsed >}}
 
-## [GIMP CUDA-Plugin](https://github.com/hashier/gicu/)
+## [idleSound](https://hashier.github.io/idleSound/)
 
-GIMP plugin written to use GPU acceleration.
+Automatically mutes your Mac when it becomes idle or the screen locks. Configurable idle time and screen-lock thresholds.
 
-The plugin extends GIMP to apply various filters on images with the help of the graphics card.
-This is done by transfer of heavy calculations to the GPU.
+![idleSound menu bar](https://raw.githubusercontent.com/hashier/idleSound/master/images/Screenshot.png)
 
-As far as I know, this was the very first every written GIMP plugin
-that off loaded the heavy math calculations to the graphics card.
+{{< langUsed >}}Objective-C, macOS menu bar app.{{< /langUsed >}}
 
-Written in C, X11, GTK+ and CUDA.
+## [CBP Compiler](https://github.com/hashier/cbp)
 
-## [SuperSaft](https://github.com/hashier/SuperSaft/)
+Compiler for a custom programming language, built with Bison and Flex. Lexer, parser, AST, and code generation.
 
-Implementation of the SAFT protocol.
+{{< langUsed >}}C++.{{< /langUsed >}}
 
-It is fully functional and compatible with the original client and server.
-More information about the protocol can be found here in this pre-RFC:
+## [GIMP CUDA Plugin](https://github.com/hashier/gicu/)
 
-<https://linux.math.tifr.res.in/manuals/text/sendfile.txt>
+One of the first GIMP plugins to offload image filter computation to the GPU. Extends GIMP with GPU-accelerated filters by transferring heavy calculations to the graphics card via CUDA.
 
-Written in ANSI C.
+{{< langUsed >}}C, GTK+, CUDA.{{< /langUsed >}}
 
-## [flicp](https://www.fli4l.de/)
+## [SuperSAFT](https://github.com/hashier/SuperSAFT/)
 
-My initiation into the world of developing software.
+Full implementation of the [SAFT](https://linux.math.tifr.res.in/manuals/text/sendfile.txt) file transfer protocol, compatible with the original client and server.
 
-fli4l.de is a Linux based ISDN-, DSL- and Ethernet-router.
-The communication with the system service utilized a special
-protocol that was only implemented in a program for Windows.
-I wrote flicp to be able to transfer files to and from Unix/Linux
-based systems to the service
+{{< langUsed >}}ANSI C.{{< /langUsed >}}
 
-Written in ANSI C.
+## [flicp](https://github.com/hashier/flicp)
+
+My first C project. A file transfer client for [fli4l](https://www.fli4l.de/) Linux routers, implementing a proprietary protocol that previously only had a Windows client.
+
+{{< langUsed >}}ANSI C.{{< /langUsed >}}

--- a/homepage/layouts/partials/header.html
+++ b/homepage/layouts/partials/header.html
@@ -1,0 +1,24 @@
+<h1 class="site-header">
+    <a href="{{ .Site.BaseURL | relLangURL }}">{{ .Site.Title }}</a>
+</h1>
+<nav>
+    {{ $currentPage := . }}
+    {{ range .Site.Menus.main }}
+    <a class="{{if or ($currentPage.IsMenuCurrent "main" .) ($currentPage.HasMenuCurrent "main" .) }} active{{end}}" href="{{ .URL | absLangURL }}" title="{{ .Title }}">{{ .Name }}</a>
+    {{ end }}
+    <label class="theme-switch" aria-label="Toggle dark mode" title="Toggle dark mode">
+        <span class="theme-icon">◐</span>
+        <input type="checkbox" class="theme-toggle">
+        <span class="slider"></span>
+    </label>
+</nav>
+<script>
+(function() {
+    var toggle = document.querySelector('.theme-toggle');
+    var isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    toggle.checked = isDark;
+    toggle.addEventListener('change', function() {
+        document.documentElement.setAttribute('data-theme', toggle.checked ? 'dark' : 'light');
+    });
+})();
+</script>

--- a/homepage/layouts/shortcodes/langUsed.html
+++ b/homepage/layouts/shortcodes/langUsed.html
@@ -1,0 +1,1 @@
+<small>{{ .Inner }}</small>

--- a/homepage/static/css/custom.css
+++ b/homepage/static/css/custom.css
@@ -2,40 +2,120 @@ small {
     color: #888;
 }
 
+/* Theme toggle slider */
+.theme-switch {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0;
+    margin-left: 2em;
+    vertical-align: middle;
+    cursor: pointer;
+}
+
+.theme-icon {
+    font-size: 0.9em;
+    color: #888;
+}
+
+.theme-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.theme-switch .slider {
+    position: relative;
+    display: inline-block;
+    width: 36px;
+    height: 20px;
+    background-color: #ccc;
+    border-radius: 20px;
+    transition: background-color 0.2s;
+}
+
+.theme-switch .slider::before {
+    position: absolute;
+    content: "";
+    height: 14px;
+    width: 14px;
+    left: 3px;
+    bottom: 3px;
+    background-color: #fff;
+    border-radius: 50%;
+    transition: transform 0.2s;
+}
+
+.theme-switch input:checked + .slider {
+    background-color: #555;
+}
+
+.theme-switch input:checked + .slider::before {
+    transform: translateX(16px);
+}
+
+/* Dark mode: system preference (default, no toggle clicked) */
 @media (prefers-color-scheme: dark) {
-    /* main */
-    body {
+    html:not([data-theme="light"]) body {
         color: #fafafa;
         background: #232323;
     }
 
-    /* Pager */
-    .pagination-item {
+    html:not([data-theme="light"]) .pagination-item {
         background: #333;
     }
 
-    .pagination-item a {
+    html:not([data-theme="light"]) .pagination-item a {
         color: #fafafa;
     }
 
-    /* Navigation */
-    header a {
+    html:not([data-theme="light"]) header a {
         color: #9b9b9b;
     }
 
-    header nav {
+    html:not([data-theme="light"]) header nav {
         background: #232323;
     }
 
-    /* Title of posts */
-    article header h1 a {
+    html:not([data-theme="light"]) article header h1 a {
         color: #ccc;
     }
 
     @media (max-width: 840px) {
-        /* Have a nice box around menu on phones */
-        header nav {
+        html:not([data-theme="light"]) header nav {
             background: #333;
         }
+    }
+}
+
+/* Dark mode: manual override */
+[data-theme="dark"] body {
+    color: #fafafa;
+    background: #232323;
+}
+
+[data-theme="dark"] .pagination-item {
+    background: #333;
+}
+
+[data-theme="dark"] .pagination-item a {
+    color: #fafafa;
+}
+
+[data-theme="dark"] header a {
+    color: #9b9b9b;
+}
+
+[data-theme="dark"] header nav {
+    background: #232323;
+}
+
+[data-theme="dark"] article header h1 a {
+    color: #ccc;
+}
+
+@media (max-width: 840px) {
+    [data-theme="dark"] header nav {
+        background: #333;
     }
 }

--- a/homepage/static/css/custom.css
+++ b/homepage/static/css/custom.css
@@ -1,3 +1,7 @@
+small {
+    color: #888;
+}
+
 @media (prefers-color-scheme: dark) {
     /* main */
     body {


### PR DESCRIPTION
## Summary

- **About page**: Rewrite bio to balance security leadership with technical depth. Emphasize security strategy, engineering culture, and shipping to hundreds of millions of users. Link open-source contributions. Update experience to 25+ years.
- **Projects page**: Curate to 9 selected projects ordered by recency. Add featured images for visual projects. New `langUsed` shortcode for de-emphasized language/tech annotations.
- **Dark mode toggle**: Session-only slider in header nav with ◐ icon. Defaults to system preference, no persistence.

## Test plan

- [ ] About page reads well, links work
- [ ] Projects page shows images, `langUsed` renders as small grey text
- [ ] Dark mode toggle switches between light/dark
- [ ] Refresh resets to system preference
- [ ] Hugo builds without warnings